### PR TITLE
call stock prices api from frontend

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,16 @@
+// This is a manifest file that'll be compiled into application.js, which will include all the files
+// listed below.
+//
+// Any JavaScript/Coffee file within this directory, lib/assets/javascripts, or any plugin's
+// vendor/assets/javascripts directory can be referenced here using a relative path.
+//
+// It's not advisable to add code directly here, but if you do, it'll appear at the bottom of the
+// compiled file. JavaScript code in this file should be added after the last require_* statement.
+//
+// Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
+// about supported directives.
+//
+//= require rails-ujs
+//= require_tree .
+//= require jquery3
+//= require jquery_ujs

--- a/frontend/actions/companies_actions.js
+++ b/frontend/actions/companies_actions.js
@@ -6,8 +6,7 @@ export const START_LOADING_INTRADAY_PRICES = 'START_LOADING_INTRADAY_PRICES';
 export const START_LOADING_DAILY_PRICES = 'START_LOADING_DAILY_PRICES';
 export const RECEIVE_COMPANIES = 'RECEIVE_COMPANIES';
 export const RECEIVE_COMPANY = 'RECEIVE_COMPANY';
-export const RECEIVE_INTRADAY_DATA = 'RECEIVE_INTRADAY_DATA';
-export const RECEIVE_DAILY_DATA = 'RECEIVE_DAILY_DATA';
+export const RECEIVE_STOCK_PRICES = 'RECEIVE_STOCK_PRICES';
 export const RECEIVE_NO_DATA = 'RECEIVE_NO_DATA';
 
 export const startLoadingAllCompanies = () => ({
@@ -36,15 +35,9 @@ export const receiveCompany = company => ({
   company
 });
 
-export const receiveIntradayData = data => ({
-  type: RECEIVE_INTRADAY_DATA,
+export const receiveStockPrices = data => ({
+  type: RECEIVE_STOCK_PRICES,
   data
-});
-
-export const receiveDailyData = (data, symbol) => ({
-  type: RECEIVE_DAILY_DATA,
-  data,
-  symbol
 });
 
 export const receiveNoData = () => ({
@@ -73,27 +66,22 @@ export const fetchCompany = id => dispatch => {
   );
 };
 
-export const fetchRealtimeIntradayData = sym => dispatch => {
+export const fetchIntradayStockPrices = (sym) => dispatch => {
   dispatch(startLoadingIntradayPrices());
-  return APIUtil.fetchRealtimeIntradayData(sym)
+  return APIUtil.fetchStockPrices(sym, 'intraday')
     .then(data => (
-      dispatch(receiveIntradayData(data))
+      dispatch(receiveStockPrices(data))
     )
   );
 };
 
-export const fetchRealtimeDailyData = sym => dispatch => {
+export const fetchDailyStockPrices = sym => dispatch => {
   dispatch(startLoadingDailyPrices());
-  return APIUtil.fetchRealtimeDailyData(sym)
+  return APIUtil.fetchStockPrices(sym, 'daily')
     .then(data => (
-      dispatch(receiveDailyData(data, sym))
+      dispatch(receiveStockPrices(data, sym))
     )
   );
-};
-
-export const fetchRealtimeData = sym => {
-  dispatch(fetchRealtimeDailyData(sym));
-  dispatch(fetchRealtimeIntradayData(sym));
 };
 
 export const clearRealtimeData = () => dispatch => {

--- a/frontend/components/app.jsx
+++ b/frontend/components/app.jsx
@@ -19,7 +19,7 @@ import { fetchRealtimeData } from '../actions/companies_actions';
 class App extends React.Component {
   componentWillMount() {
     setTimeout(() => this.props.fetchCompanies(), 900);
-    // this.props.symbols.forEach(symbol => this.props.fetchRealtimeIntradayData(symbol));
+    // this.props.symbols.forEach(symbol => this.props.fetchIntradayStockPrices(symbol));
   }
 
   componentWillUnmount() {

--- a/frontend/components/app_container.js
+++ b/frontend/components/app_container.js
@@ -4,8 +4,8 @@ import { withRouter } from 'react-router-dom';
 import App from './app';
 import {
   fetchCompanies,
-  fetchRealtimeIntradayData,
-  fetchRealtimeDailyData,
+  fetchIntradayStockPrices,
+  fetchDailyStockPrices,
   clearCompanies,
   clearRealtimeData
 } from '../actions/companies_actions';
@@ -23,8 +23,8 @@ const mapStateToProps = ( state, ownProps ) => {
 
 const mapDispatchToProps = dispatch => ({
   fetchCompanies: () => dispatch(fetchCompanies()),
-  fetchRealtimeIntradayData: sym => dispatch(fetchRealtimeIntradayData(sym)),
-  fetchRealtimeDailyData: sym => dispatch(fetchRealtimeDailyData(sym)),
+  fetchIntradayStockPrices: sym => dispatch(fetchIntradayStockPrices(sym)),
+  fetchDailyStockPrices: sym => dispatch(fetchDailyStockPrices(sym)),
   clearCompanies: () => dispatch(clearCompanies()),
   clearRealtimeData: () => dispatch(clearRealtimeData()),
 });

--- a/frontend/components/company_page/chart.jsx
+++ b/frontend/components/company_page/chart.jsx
@@ -119,9 +119,9 @@ class ChartComponent extends React.Component {
     {
       const { symbol } = nextProps.match.params;
       if (!nextProps.companyStockData) {
-        this.props.fetchRealtimeIntradayData(symbol)
+        this.props.fetchIntradayStockPrices(symbol)
           .then(() => this.renderChart());
-        this.props.fetchRealtimeDailyData(symbol);
+        this.props.fetchDailyStockPrices(symbol);
       }
     }
   }
@@ -134,8 +134,8 @@ class ChartComponent extends React.Component {
     const { symbol } = this.props.match.params;
     const { companyStockData } = this.props;
     if (!companyStockData) {
-      this.props.fetchRealtimeIntradayData(symbol);
-      this.props.fetchRealtimeDailyData(symbol);
+      this.props.fetchIntradayStockPrices(symbol);
+      this.props.fetchDailyStockPrices(symbol);
     }
   }
 

--- a/frontend/components/company_page/chart_container.js
+++ b/frontend/components/company_page/chart_container.js
@@ -1,8 +1,8 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import {
-  fetchRealtimeIntradayData,
-  fetchRealtimeDailyData,
+  fetchIntradayStockPrices,
+  fetchDailyStockPrices,
 } from '../../actions/companies_actions';
 import ChartComponent from './chart';
 import {
@@ -23,8 +23,8 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = dispatch => ({
   watchCompany: id => dispatch(watchCompany(id)),
   unwatchCompany: id => dispatch(unwatchCompany(id)),
-  fetchRealtimeIntradayData: sym => dispatch(fetchRealtimeIntradayData(sym)),
-  fetchRealtimeDailyData: sym => dispatch(fetchRealtimeDailyData(sym))
+  fetchIntradayStockPrices: sym => dispatch(fetchIntradayStockPrices(sym)),
+  fetchDailyStockPrices: sym => dispatch(fetchDailyStockPrices(sym))
 });
 
 export default withRouter(

--- a/frontend/reducers/chart_reducer.js
+++ b/frontend/reducers/chart_reducer.js
@@ -1,7 +1,6 @@
 import merge from 'lodash/merge';
 import {
-  RECEIVE_INTRADAY_DATA,
-  RECEIVE_DAILY_DATA,
+  RECEIVE_STOCK_PRICES,
   RECEIVE_NO_DATA,
 } from '../actions/companies_actions';
 import { parseData, parseDailyData } from '../util/parsing_functions';
@@ -10,11 +9,9 @@ const chartReducer = (state = {}, action) => {
   Object.freeze(state);
   let parsedData;
   switch(action.type) {
-    case RECEIVE_INTRADAY_DATA:
-      parsedData = parseData(action.data, '5min');
-      return merge({}, state, parsedData);
-    case RECEIVE_DAILY_DATA:
-      parsedData = parseData(action.data, 'Daily');
+    case RECEIVE_STOCK_PRICES:
+      const { data: { symbol, last_closing_price, time_series, stock_prices } } = action;
+      parsedData = { [symbol]: { [time_series]: stock_prices, last_closing_price } };
       return merge({}, state, parsedData);
     case RECEIVE_NO_DATA:
       return {};

--- a/frontend/stock_overflow.jsx
+++ b/frontend/stock_overflow.jsx
@@ -21,8 +21,8 @@ import {
 import {
   fetchCompanies,
   fetchCompany,
-  fetchRealtimeIntradayData,
-  fetchRealtimeDailyData,
+  fetchIntradayStockPrices,
+  fetchDailyStockPrices,
   fetchRealtimeData,
 } from './actions/companies_actions';
 import { parseRealData } from './util/parsing_functions';
@@ -40,8 +40,8 @@ import {
 document.addEventListener('DOMContentLoaded', () => {
 
   // testing...
-  window.fetchRealtimeIntradayData = fetchRealtimeIntradayData;
-  window.fetchRealtimeDailyData = fetchRealtimeDailyData;
+  window.fetchIntradayStockPrices = fetchIntradayStockPrices;
+  window.fetchDailyStockPrices = fetchDailyStockPrices;
   window.fetchRealtimeData = fetchRealtimeData;
   //
 

--- a/frontend/util/companies_api_util.js
+++ b/frontend/util/companies_api_util.js
@@ -12,18 +12,9 @@ export const fetchCompany = id => (
   })
 );
 
-export const fetchRealtimeIntradayData = sym => (
+export const fetchStockPrices = (sym, time_series) => (
   $.ajax({
-    url: `https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=${sym}&outputsize=full&apikey=${API_OPTIONS.alphaVantageApiKey}&interval=5min`,
-    type: "GET",
-    dataType: "JSON",
-  })
-);
-
-export const fetchRealtimeDailyData = sym => (
-  $.ajax({
-    url: `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=${sym}&outputsize=full&apikey=${API_OPTIONS.alphaVantageApiKey}`,
-    type: "GET",
-    dataType: "JSON",
+    method: 'GET',
+    url: `/api/stock_prices/${sym}/?time_series=${time_series}`
   })
 );


### PR DESCRIPTION
closes #20 


- remove `fetchRealtimeIntradayData ` api call to Alpha Vantage to call api endpoint from backend to retrieve intraday stock prices
- remove `fetchRealtimeDailyData ` api call to Alpha Vantage to call api endpoint from backend to retrieve daily stock prices
- change `fetchRealtimeIntradayData` to `fetchIntradayStockPrices `
- change `fetchRealtimeDailyData` to `fetchDailyStockPrices `